### PR TITLE
Add link to consistency fundamentals to README

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -320,7 +320,7 @@ Microsoft REST API Guidelines compliant APIs SHOULD support PATCH.
 #### 7.4.3 Creating resources via PATCH (UPSERT semantics)
 Services that allow callers to specify key values on create SHOULD support UPSERT semantics, and those that do MUST support creating resources using PATCH.
 Because PUT is defined as a complete replacement of the content, it is dangerous for clients to use PUT to modify data.
-Clients that do not understand (and hence ignore) properties on a resource are not likely to provide them on a PUT when trying to update a resource, hence such properties MAY be inadvertently removed.
+Clients that do not understand (and hence ignore) properties on a resource are not likely to provide them on a PUT when trying to update a resource, hence such properties could be inadvertently removed.
 Services MAY optionally support PUT to update existing resources, but if they do they MUST use replacement semantics (that is, after the PUT, the resource's properties MUST match what was provided in the request, including deleting any server properties that were not provided).
 
 Under UPSERT semantics, a PATCH call to a nonexistent resource is handled by the server as a "create," and a PATCH call to an existing resource is handled as an "update." To ensure that an update request is not treated as a create or vice-versa, the client MAY specify precondition HTTP headers in the request.

--- a/Guidelines.md
+++ b/Guidelines.md
@@ -1,7 +1,7 @@
 # Microsoft REST API Guidelines
 ## Microsoft REST API Guidelines Working Group
 
- | | |
+Name | Name | Name |
 ---------------------------- | -------------------------------------- | ----------------------------------------
 Dave Campbell (CTO C+E)      | Rick Rashid (CTO ASG)                  | John Shewchuk (Technical Fellow, TED HQ)
 Mark Russinovich (CTO Azure) | Steve Lucco (Technical Fellow, DevDiv) | Murali Krishnaprasad (Azure App Plat)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Microsoft REST API Guidelines
-The [Microsoft REST API Guidelines](Guidelines.md), as a design principle, encourages application developers to have resources accessible to them via a RESTful HTTP interface. To provide the smoothest possible experience for developers on platforms following the Microsoft REST API Guidelines, REST APIs SHOULD follow consistent design guidelines to make using them easy and intuitive.
+The [Microsoft REST API Guidelines](Guidelines.md), as a design principle, encourages application developers to have resources accessible to them via a RESTful HTTP interface. To provide the smoothest possible experience for developers on platforms following the Microsoft REST API Guidelines, REST APIs SHOULD follow [consistent design guidelines](https://github.com/IAmHughes/api-guidelines/blob/vNext/Guidelines.md#7-consistency-fundamentals) to make using them easy and intuitive.
 
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
This is a quality of life add to the README to link directly to the consistency fundamentals section of the guidelines.